### PR TITLE
Изменения в манифесте

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": 3,
+  "author": "kir1l",
   "name": "Switcher",
   "description": "Extension that changes the language of the written text",
   "version": "1.0",
@@ -11,18 +12,19 @@
       }
    ],
    "action": {
-      "default_popup": "./popup/popup.html"
+      "default_popup": "./popup/popup.html",
+      "default_title": "Switcher",
+      "default_icon": {
+        "16": "./icons/icon16x16.png",
+        "32": "./icons/icon32x32.png",
+        "48": "./icons/icon64x64.png",
+        "128": "./icons/icon128x128.png"
+      }
    },
    "permissions": [
       "storage"
    ],
    "background": {
       "service_worker": "./background.js"
-   },
-   "icons": {
-      "16": "./icons/icon16x16.png",
-      "32": "./icons/icon32x32.png",
-      "48": "./icons/icon64x64.png",
-      "128": "./icons/icon128x128.png"
    }
 }


### PR DESCRIPTION
Для 3 версии манифеста было введено правило, где иконки для расширения должны располагаться в разделе `"action"`, а также важным компонентом является `"default_title"` (тот текст который будет отображаться при наведении на иконку), ну и `"author"` (то есть ты). 

Немного подробнее про блок `"action"` можно узнать, например, в доке от Mozilla (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action)

Крутое расширение!